### PR TITLE
fix: drop traffic from malicious actors on cua.browserbase

### DIFF
--- a/app/api/cua/agent/base_playwright.ts
+++ b/app/api/cua/agent/base_playwright.ts
@@ -170,6 +170,18 @@ export abstract class BasePlaywrightComputer {
   // --- Extra browser-oriented actions ---
   async goto(url: string): Promise<void> {
     if (!this._page) throw new Error("Page not initialized");
+
+    // Block malicious or restricted URLs
+    if (url.includes("gemini.browserbase.com") ||
+        url.includes("arena.browserbase.com") ||
+        url.includes("google.browserbase.com") ||
+        url.includes("google-cua.browserbase.com") ||
+        url.includes("cua.browserbase.com") ||
+        url.includes("operator.browserbase.com") ||
+        url.includes("doge.ct.ws")) {
+      throw new Error(`Navigation to ${url} is blocked for security reasons.`);
+    }
+
     await this._page.goto(url, { waitUntil: "domcontentloaded" });
   }
   


### PR DESCRIPTION
# what

don't let the demo site navigate to itself + a site that has been used to maliciously spike usage.